### PR TITLE
修复 cannot import name 'url_quote' from 'werkzeug.urls' 报错

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 Flask==2.1.0
+Werkzeug==2.3.8


### PR DESCRIPTION
![image](https://github.com/malaohu/MobaXterm-GenKey/assets/13843255/45632ec6-bfd0-4dd6-a716-fe8c0f5d88f4)
